### PR TITLE
fix: distillation loop uses wrong results_dir path

### DIFF
--- a/ml/training/distillation_loop.py
+++ b/ml/training/distillation_loop.py
@@ -62,10 +62,10 @@ class DistillationConfig:
     convergence_threshold: float = 0.01  # Min win-rate improvement to not plateau
 
     # --- Paths ---
-    results_dir: str = "data/results"
+    results_dir: str = "results"
     models_dir: str = "ml/models"
     checkpoint_dir: str = "ml/models/checkpoints"
-    history_dir: str = "data/results/distillation-history"
+    history_dir: str = "results/distillation-history"
 
     # --- Supervised training ---
     supervised_epochs: int = 30

--- a/routes/ml.py
+++ b/routes/ml.py
@@ -800,10 +800,10 @@ def _run_distillation_pipeline(
             opponent=opponent,
             playstyle=playstyle,
             min_ppo_win_rate=min_win_rate,
-            results_dir=os.path.join(project_root, "data", "results"),
+            results_dir=os.path.join(project_root, "results"),
             models_dir=os.path.join(project_root, "ml", "models"),
             checkpoint_dir=os.path.join(project_root, "ml", "models", "checkpoints"),
-            history_dir=os.path.join(project_root, "data", "results", "distillation-history"),
+            history_dir=os.path.join(project_root, "results", "distillation-history"),
         )
 
         loop = DistillationLoop(cfg)
@@ -925,8 +925,8 @@ async def ml_stop_distillation():
 async def ml_distillation_history():
     """Get distillation generation history from disk."""
     project_root = Path(__file__).resolve().parent.parent
-    history_path = project_root / "data" / "results" / "distillation-history" / "generations.json"
-    summary_path = project_root / "data" / "results" / "distillation-history" / "summary.json"
+    history_path = project_root / "results" / "distillation-history" / "generations.json"
+    summary_path = project_root / "results" / "distillation-history" / "summary.json"
 
     result = {"generations": [], "summary": None}
 


### PR DESCRIPTION
The distillation pipeline was looking for JSONL files in `data/results/` but they live in `results/` (matching `CFG.results_dir`). This caused all 10 generations to fail at Step 1 with 'No ml-decisions-*.jsonl files found'.