### PR TITLE
feat: commander damage source identity and per-card tracking

### DIFF
--- a/src/commander_ai_lab/sim/engine.py
+++ b/src/commander_ai_lab/sim/engine.py
@@ -557,12 +557,16 @@ class GameEngine:
       atk_names = [f"{a.name} ({a.pt})" for a in attackers]
       events.append(f"Attacks {opp.name} with: {', '.join(atk_names)}")
     total_damage = 0
+    # Per-commander-card damage dealt to the opponent this combat.
+    # Key = attacker card name; only populated for is_commander cards.
+    cmd_damage_by_card: dict[str, int] = {}
     used_blockers: set[int] = set()
     combat_details: list[str] = []
     for atk in attackers:
       a_pow = atk.get_power()
       a_tou = atk.get_toughness()
       has_flying = atk.has_keyword("flying")
+      is_commander_atk = atk.is_commander
       valid_blockers = [
         b
         for b in opp_blockers
@@ -608,11 +612,17 @@ class GameEngine:
           if atk.has_keyword("trample") and a_pow > blocker.get_toughness():
             trample_over = a_pow - blocker.get_toughness()
             total_damage += trample_over
+            if is_commander_atk:
+              cmd_damage_by_card[atk.name] = cmd_damage_by_card.get(atk.name, 0) + trample_over
           if atk.has_keyword("double strike"):
             if a_pow >= blocker.get_toughness() or atk.has_keyword("deathtouch"):
               total_damage += a_pow
+              if is_commander_atk:
+                cmd_damage_by_card[atk.name] = cmd_damage_by_card.get(atk.name, 0) + a_pow
             else:
               total_damage += trample_over
+              if is_commander_atk:
+                cmd_damage_by_card[atk.name] = cmd_damage_by_card.get(atk.name, 0) + trample_over
           if atk.has_keyword("lifelink"):
             damage_dealt = min(a_pow, blocker.get_toughness()) + trample_over
             if atk.has_keyword("double strike"):
@@ -621,19 +631,39 @@ class GameEngine:
       if not blocked:
         if atk.has_keyword("double strike"):
           total_damage += a_pow * 2
+          if is_commander_atk:
+            cmd_damage_by_card[atk.name] = cmd_damage_by_card.get(atk.name, 0) + a_pow * 2
           if atk.has_keyword("lifelink"):
             p.life += a_pow * 2
         else:
           total_damage += a_pow
+          if is_commander_atk:
+            cmd_damage_by_card[atk.name] = cmd_damage_by_card.get(atk.name, 0) + a_pow
           if atk.has_keyword("lifelink"):
             p.life += a_pow
+    # Apply damage to opponent
     opp.life -= total_damage
     p.stats.damage_dealt += total_damage
     opp.stats.damage_received += total_damage
+    # Track commander damage — both per-seat aggregate and per-card breakdown
+    total_cmd_damage = sum(cmd_damage_by_card.values())
+    if total_cmd_damage > 0:
+      opp.commander_damage_received[pi] = (
+        opp.commander_damage_received.get(pi, 0) + total_cmd_damage
+      )
+      for cmd_name, dmg in cmd_damage_by_card.items():
+        key = (pi, cmd_name)
+        opp.commander_damage_by_card[key] = (
+          opp.commander_damage_by_card.get(key, 0) + dmg
+        )
     if events is not None and total_damage > 0:
-      events.append(f"Dealt {total_damage} combat damage to {opp.name} (now {opp.life} life)")
+      cmd_note = f" ({total_cmd_damage} cmdr)" if total_cmd_damage > 0 else ""
+      events.append(
+        f"Dealt {total_damage} combat damage{cmd_note} to {opp.name} (now {opp.life} life)"
+      )
       events.extend(combat_details)
-    if opp.life <= 0:
+    # Check elimination: life <= 0 or commander damage >= 21
+    if opp.life <= 0 or opp.is_dead_to_commander_damage():
       opp.eliminated = True
 
   def _build_result(

--- a/src/commander_ai_lab/sim/game_state.py
+++ b/src/commander_ai_lab/sim/game_state.py
@@ -95,9 +95,6 @@ class CommanderPlayer:
     # Whether this player has drawn their card this turn
     drawn_this_turn: bool = False
 
-    # Commander damage received from each opponent (keyed by seat index)
-    commander_damage_received: dict[int, int] = field(default_factory=dict)
-
     # ── Convenience pass-throughs to base Player ─────────────
 
     @property
@@ -136,13 +133,18 @@ class CommanderPlayer:
     def library(self) -> list[Card]:
         return self.base.library
 
+    @property
+    def commander_damage_received(self) -> dict[int, int]:
+        """Delegate to base Player so headless engine writes are visible."""
+        return self.base.commander_damage_received
+
     def commander_tax(self) -> int:
         """Additional mana cost (2 per cast from command zone)."""
         return self.commander_cast_count * 2
 
     def is_dead_to_commander_damage(self) -> bool:
-        """Returns True if any single opponent has dealt 21+ commander damage."""
-        return any(v >= 21 for v in self.commander_damage_received.values())
+        """Returns True if any single commander has dealt 21+ damage."""
+        return self.base.is_dead_to_commander_damage()
 
     def to_dict(self) -> dict:
         return {
@@ -247,13 +249,25 @@ class CommanderGameState:
             return p.commander_damage_received.get(from_seat, 0)
         return 0
 
-    def deal_commander_damage(self, from_seat: int, to_seat: int, amount: int) -> None:
-        """Record commander damage and reduce life total."""
+    def deal_commander_damage(
+        self, from_seat: int, to_seat: int, amount: int,
+        commander_name: str | None = None,
+    ) -> None:
+        """Record commander damage and reduce life total.
+
+        If *commander_name* is provided the per-card breakdown is also
+        updated (needed for partner-correct 21-damage checks).
+        """
         if to_seat < len(self.commander_players):
             p = self.commander_players[to_seat]
             p.commander_damage_received[from_seat] = (
                 p.commander_damage_received.get(from_seat, 0) + amount
             )
+            if commander_name is not None:
+                key = (from_seat, commander_name)
+                p.base.commander_damage_by_card[key] = (
+                    p.base.commander_damage_by_card.get(key, 0) + amount
+                )
             p.life -= amount
 
     # ── Serialization ────────────────────────────────────────

--- a/src/commander_ai_lab/sim/models.py
+++ b/src/commander_ai_lab/sim/models.py
@@ -152,7 +152,28 @@ class Player:
     #                           p.commander_tax[name] = tax + 2
     commander_tax: dict = field(default_factory=dict)
 
+    # Commander damage received from each opponent, keyed by seat index.
+    # This is the aggregate per-seat total (used by GUI matrix and prompt
+    # builder).  For games where a player controls partner commanders
+    # the per-card breakdown lives in commander_damage_by_card.
+    commander_damage_received: dict[int, int] = field(default_factory=dict)
+
+    # Per-commander breakdown: {(seat, card_name): damage}.
+    # In MTG rules, lethal commander damage (21+) is tracked per individual
+    # commander card, not per player.  This dict captures that.
+    commander_damage_by_card: dict[tuple[int, str], int] = field(default_factory=dict)
+
     stats: PlayerStats = field(default_factory=PlayerStats)
+
+    def is_dead_to_commander_damage(self) -> bool:
+        """Returns True if any single commander has dealt 21+ damage.
+
+        Checks per-card tracking first (partner-correct); falls back to
+        per-seat totals for backward compatibility with older game states.
+        """
+        if self.commander_damage_by_card:
+            return any(v >= 21 for v in self.commander_damage_by_card.values())
+        return any(v >= 21 for v in self.commander_damage_received.values())
 
 
 @dataclass

--- a/tests/test_commander_damage.py
+++ b/tests/test_commander_damage.py
@@ -1,0 +1,410 @@
+"""
+Commander Damage Regression Tests
+==================================
+Run with: pytest tests/test_commander_damage.py -v
+
+Covers:
+  - Commander source identity during combat
+  - Trample overflow counts as commander damage
+  - Double strike commander damage
+  - Partner / multi-commander per-card tracking
+  - 21-damage lethal check (per-card, not per-seat)
+  - Commander damage through CommanderGameState helper
+  - Non-commander creatures do NOT generate commander damage
+  - Lifelink + commander damage interaction
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from commander_ai_lab.sim.models import Card, Player, PlayerStats, SimState
+from commander_ai_lab.sim.engine import GameEngine
+from commander_ai_lab.sim.game_state import (
+    CommanderGameState,
+    CommanderPlayer,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+def _make_creature(
+    name: str,
+    power: str = "3",
+    toughness: str = "3",
+    keywords: list[str] | None = None,
+    is_commander: bool = False,
+) -> Card:
+    c = Card(
+        name=name,
+        type_line="Legendary Creature" if is_commander else "Creature",
+        cmc=3,
+        power=power,
+        toughness=toughness,
+        keywords=keywords or [],
+        is_commander=is_commander,
+    )
+    return c
+
+
+def _make_land(name: str = "Mountain") -> Card:
+    return Card(name=name, type_line="Basic Land", cmc=0)
+
+
+def _setup_combat(
+    attacker_creatures: list[Card],
+    blocker_creatures: list[Card] | None = None,
+    attacker_life: int = 40,
+    defender_life: int = 40,
+) -> tuple[GameEngine, SimState, int, int]:
+    """Set up a 2-player SimState ready for _resolve_combat.
+
+    Returns (engine, sim, attacker_seat, defender_seat).
+    Attacker is seat 0, defender is seat 1.
+    All creatures are pre-placed on battlefield, untapped, played on a previous turn.
+    """
+    engine = GameEngine(max_turns=25, starting_life=40, record_log=True)
+    sim = SimState(max_turns=25)
+    sim.turn = 5  # so creatures played earlier pass summoning sickness check
+
+    p0 = Player(name="Attacker", life=attacker_life, owner_id=0, stats=PlayerStats())
+    p1 = Player(name="Defender", life=defender_life, owner_id=1, stats=PlayerStats())
+    sim.players = [p0, p1]
+    sim.init_battlefields(2)
+
+    card_id = 90000
+    for c in attacker_creatures:
+        c.owner_id = 0
+        c.tapped = False
+        c.turn_played = 1  # played on an earlier turn
+        c.id = card_id
+        card_id += 1
+        sim.add_to_battlefield(0, c)
+
+    for c in (blocker_creatures or []):
+        c.owner_id = 1
+        c.tapped = False
+        c.turn_played = 1
+        c.id = card_id
+        card_id += 1
+        sim.add_to_battlefield(1, c)
+
+    sim.next_card_id = card_id
+    return engine, sim, 0, 1
+
+
+# ── Tests: Basic commander damage tracking ───────────────────
+
+
+class TestCommanderDamageBasic:
+    """Commander creatures attacking unblocked should generate
+    commander damage tracked on the defending player."""
+
+    def test_unblocked_commander_deals_commander_damage(self):
+        cmd = _make_creature("Krenko", "5", "5", is_commander=True)
+        engine, sim, pi, oi = _setup_combat([cmd])
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        opp = sim.players[oi]
+        # Life reduced
+        assert opp.life == 35
+        # Per-seat aggregate
+        assert opp.commander_damage_received[pi] == 5
+        # Per-card breakdown
+        assert opp.commander_damage_by_card[(pi, "Krenko")] == 5
+
+    def test_unblocked_non_commander_no_commander_damage(self):
+        creature = _make_creature("Goblin", "4", "4", is_commander=False)
+        engine, sim, pi, oi = _setup_combat([creature])
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        opp = sim.players[oi]
+        assert opp.life == 36
+        assert opp.commander_damage_received == {}
+        assert opp.commander_damage_by_card == {}
+
+    def test_mixed_attackers_only_commander_tracked(self):
+        cmd = _make_creature("Krenko", "3", "3", is_commander=True)
+        grunt = _make_creature("Goblin", "2", "2", is_commander=False)
+        engine, sim, pi, oi = _setup_combat([cmd, grunt])
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        opp = sim.players[oi]
+        # Total damage = 3 + 2 = 5
+        assert opp.life == 35
+        # Only commander damage tracked
+        assert opp.commander_damage_received[pi] == 3
+        assert opp.commander_damage_by_card[(pi, "Krenko")] == 3
+
+    def test_cumulative_commander_damage_across_combats(self):
+        cmd = _make_creature("Krenko", "5", "5", is_commander=True)
+        engine, sim, pi, oi = _setup_combat([cmd])
+        # First combat
+        engine._resolve_combat(sim, pi, sim.turn, [])
+        assert sim.players[oi].commander_damage_received[pi] == 5
+        # Reset tapped state for second combat
+        cmd.tapped = False
+        sim.turn += 1
+        engine._resolve_combat(sim, pi, sim.turn, [])
+        assert sim.players[oi].commander_damage_received[pi] == 10
+        assert sim.players[oi].commander_damage_by_card[(pi, "Krenko")] == 10
+
+
+# ── Tests: Commander damage lethal (21+) ─────────────────────
+
+
+class TestCommanderDamageLethal:
+
+    def test_21_damage_eliminates(self):
+        cmd = _make_creature("Krenko", "7", "7", is_commander=True)
+        engine, sim, pi, oi = _setup_combat([cmd], defender_life=100)
+        # Deal 7 per combat, need 3 combats = 21
+        for _ in range(3):
+            cmd.tapped = False
+            engine._resolve_combat(sim, pi, sim.turn, [])
+            sim.turn += 1
+        opp = sim.players[oi]
+        assert opp.commander_damage_received[pi] == 21
+        assert opp.eliminated
+
+    def test_20_damage_not_lethal(self):
+        """20 commander damage should NOT eliminate."""
+        p = Player(name="Test", life=40)
+        p.commander_damage_received = {0: 20}
+        p.commander_damage_by_card = {(0, "Krenko"): 20}
+        assert not p.is_dead_to_commander_damage()
+
+    def test_21_per_card_not_per_seat(self):
+        """With partners, 21 must come from a SINGLE commander, not combined."""
+        p = Player(name="Test", life=40)
+        # Two partner commanders from seat 0, 11 each = 22 total but neither is 21
+        p.commander_damage_by_card = {
+            (0, "Brallin"): 11,
+            (0, "Shabraz"): 11,
+        }
+        p.commander_damage_received = {0: 22}
+        assert not p.is_dead_to_commander_damage()
+
+    def test_21_from_one_partner_is_lethal(self):
+        """If one partner reaches 21, that's lethal even if the other has 0."""
+        p = Player(name="Test", life=40)
+        p.commander_damage_by_card = {
+            (0, "Brallin"): 21,
+            (0, "Shabraz"): 3,
+        }
+        p.commander_damage_received = {0: 24}
+        assert p.is_dead_to_commander_damage()
+
+    def test_backward_compat_no_by_card(self):
+        """If commander_damage_by_card is empty, fall back to per-seat check."""
+        p = Player(name="Test", life=40)
+        p.commander_damage_received = {0: 21}
+        # No by_card data (older game state)
+        assert p.is_dead_to_commander_damage()
+
+
+# ── Tests: Trample commander damage ──────────────────────────
+
+
+class TestCommanderDamageTrample:
+
+    def test_trample_overflow_is_commander_damage(self):
+        """When a commander with trample is chump-blocked, overflow to
+        the player should count as commander damage."""
+        cmd = _make_creature("Ghalta", "12", "12", keywords=["trample"], is_commander=True)
+        # Defender life low enough that AI decides to chump-block
+        # (opp.life <= a_pow * 2  ⇒  20 <= 24)
+        blocker = _make_creature("Bear", "2", "2")
+        engine, sim, pi, oi = _setup_combat([cmd], [blocker], defender_life=20)
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        opp = sim.players[oi]
+        # Bear (2/2) chump-blocks Ghalta (12/12 trample).
+        # Trample overflow = 12 - 2 = 10 damage to player.
+        assert opp.commander_damage_received[pi] == 10
+        assert opp.commander_damage_by_card[(pi, "Ghalta")] == 10
+        assert opp.life == 10
+
+    def test_fully_blocked_commander_no_player_damage(self):
+        """Commander fully absorbed by a survivable blocker — no commander
+        damage to the defending player."""
+        cmd = _make_creature("Krenko", "3", "3", is_commander=True)
+        # Blocker toughness > attacker power so AI selects it
+        blocker = _make_creature("Wall", "0", "5")
+        engine, sim, pi, oi = _setup_combat([cmd], [blocker])
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        opp = sim.players[oi]
+        # No damage to player (absorbed by blocker, no trample)
+        assert opp.life == 40
+        assert opp.commander_damage_received == {}
+
+
+# ── Tests: Double strike commander damage ────────────────────
+
+
+class TestCommanderDamageDoubleStrike:
+
+    def test_unblocked_double_strike_commander(self):
+        cmd = _make_creature("Rafiq", "5", "5", keywords=["double strike"], is_commander=True)
+        engine, sim, pi, oi = _setup_combat([cmd])
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        opp = sim.players[oi]
+        # Double strike unblocked = power * 2
+        assert opp.life == 30
+        assert opp.commander_damage_received[pi] == 10
+        assert opp.commander_damage_by_card[(pi, "Rafiq")] == 10
+
+
+# ── Tests: Partner / multi-commander ─────────────────────────
+
+
+class TestPartnerCommanderDamage:
+
+    def test_two_partner_commanders_tracked_separately(self):
+        cmd_a = _make_creature("Brallin", "4", "4", is_commander=True)
+        cmd_b = _make_creature("Shabraz", "3", "3", is_commander=True)
+        engine, sim, pi, oi = _setup_combat([cmd_a, cmd_b])
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        opp = sim.players[oi]
+        # Total damage = 4 + 3 = 7
+        assert opp.life == 33
+        # Aggregate per-seat
+        assert opp.commander_damage_received[pi] == 7
+        # Per-card individual
+        assert opp.commander_damage_by_card[(pi, "Brallin")] == 4
+        assert opp.commander_damage_by_card[(pi, "Shabraz")] == 3
+
+    def test_partner_21_check_per_card(self):
+        """Even with partners, only 21 from ONE commander kills."""
+        cmd_a = _make_creature("Brallin", "7", "7", is_commander=True)
+        cmd_b = _make_creature("Shabraz", "7", "7", is_commander=True)
+        engine, sim, pi, oi = _setup_combat([cmd_a, cmd_b], defender_life=100)
+        # 3 combats: 7*3=21 for Brallin, 7*3=21 for Shabraz
+        # After 2 combats: 14 each — not lethal
+        for _ in range(2):
+            cmd_a.tapped = False
+            cmd_b.tapped = False
+            engine._resolve_combat(sim, pi, sim.turn, [])
+            sim.turn += 1
+        opp = sim.players[oi]
+        assert not opp.eliminated  # 14 from each, neither is 21
+        # 3rd combat pushes both to 21
+        cmd_a.tapped = False
+        cmd_b.tapped = False
+        engine._resolve_combat(sim, pi, sim.turn, [])
+        assert opp.eliminated
+
+
+# ── Tests: CommanderGameState integration ────────────────────
+
+
+class TestCommanderGameStateDamage:
+
+    def test_deal_commander_damage_with_name(self):
+        sim = SimState()
+        sim.init_battlefields(2)
+        for i in range(2):
+            sim.players.append(Player(name=f"P{i}", life=40, owner_id=i))
+        gs = CommanderGameState.from_sim_state(sim)
+        gs.deal_commander_damage(0, 1, 10, commander_name="Krenko")
+        cp = gs.commander_players[1]
+        assert cp.commander_damage_received[0] == 10
+        assert cp.base.commander_damage_by_card[(0, "Krenko")] == 10
+        assert cp.life == 30
+
+    def test_deal_commander_damage_without_name_backward_compat(self):
+        sim = SimState()
+        sim.init_battlefields(2)
+        for i in range(2):
+            sim.players.append(Player(name=f"P{i}", life=40, owner_id=i))
+        gs = CommanderGameState.from_sim_state(sim)
+        gs.deal_commander_damage(0, 1, 10)
+        cp = gs.commander_players[1]
+        assert cp.commander_damage_received[0] == 10
+        assert cp.base.commander_damage_by_card == {}
+        assert cp.life == 30
+
+    def test_commander_player_property_delegates_to_base(self):
+        """CommanderPlayer.commander_damage_received should be the same
+        object as base.commander_damage_received."""
+        p = Player(name="Test", life=40)
+        cp = CommanderPlayer(base=p)
+        # Write through base
+        p.commander_damage_received[0] = 15
+        # Read through wrapper
+        assert cp.commander_damage_received[0] == 15
+        # Write through wrapper
+        cp.commander_damage_received[1] = 7
+        assert p.commander_damage_received[1] == 7
+
+
+# ── Tests: Event log annotation ──────────────────────────────
+
+
+class TestCommanderDamageEvents:
+
+    def test_event_log_includes_cmdr_annotation(self):
+        cmd = _make_creature("Krenko", "5", "5", is_commander=True)
+        engine, sim, pi, oi = _setup_combat([cmd])
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        # Should mention commander damage in the event text
+        damage_event = [e for e in events if "combat damage" in e]
+        assert len(damage_event) == 1
+        assert "5 cmdr" in damage_event[0]
+
+    def test_no_cmdr_annotation_for_non_commanders(self):
+        grunt = _make_creature("Goblin", "3", "3", is_commander=False)
+        engine, sim, pi, oi = _setup_combat([grunt])
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        damage_event = [e for e in events if "combat damage" in e]
+        assert len(damage_event) == 1
+        assert "cmdr" not in damage_event[0]
+
+
+# ── Tests: Lifelink + commander interaction ──────────────────
+
+
+class TestCommanderDamageLifelink:
+
+    def test_commander_with_lifelink_heals_and_tracks(self):
+        cmd = _make_creature("Oloro", "5", "5", keywords=["lifelink"], is_commander=True)
+        engine, sim, pi, oi = _setup_combat([cmd])
+        events: list[str] = []
+        engine._resolve_combat(sim, pi, sim.turn, events)
+        attacker = sim.players[pi]
+        opp = sim.players[oi]
+        # Commander damage tracked
+        assert opp.commander_damage_received[pi] == 5
+        # Lifelink healed attacker
+        assert attacker.life == 45
+        # Defender took damage
+        assert opp.life == 35
+
+
+# ── Tests: Player model ─────────────────────────────────────
+
+
+class TestPlayerCommanderDamageModel:
+
+    def test_fresh_player_has_empty_tracking(self):
+        p = Player(name="Test")
+        assert p.commander_damage_received == {}
+        assert p.commander_damage_by_card == {}
+        assert not p.is_dead_to_commander_damage()
+
+    def test_is_dead_prefers_by_card(self):
+        """When by_card data exists, per-seat aggregate is ignored for lethal check."""
+        p = Player(name="Test")
+        p.commander_damage_received = {0: 25}  # aggregate says lethal
+        p.commander_damage_by_card = {
+            (0, "CmdA"): 12,
+            (0, "CmdB"): 13,
+        }
+        # Per-card: neither commander has 21 → NOT lethal
+        assert not p.is_dead_to_commander_damage()

--- a/tests/test_phase1.py
+++ b/tests/test_phase1.py
@@ -92,9 +92,9 @@ class TestCommanderPlayer:
 
     def test_commander_damage_death(self):
         cp = CommanderPlayer(base=Player(name="Test"))
-        cp.commander_damage_received = {0: 20, 1: 5}
+        cp.base.commander_damage_received = {0: 20, 1: 5}
         assert not cp.is_dead_to_commander_damage()
-        cp.commander_damage_received[0] = 21
+        cp.base.commander_damage_received[0] = 21
         assert cp.is_dead_to_commander_damage()
 
     def test_to_dict_json_serializable(self):


### PR DESCRIPTION
## Summary
Addresses **Issue #86 item 2** — "More complete commander damage handling nuances."

- **Commander source identity at combat time**: `_resolve_combat` now checks `is_commander` on each attacking creature and tracks damage separately from non-commander attackers
- **Per-card breakdown**: New `commander_damage_by_card` dict (keyed by `(seat, card_name)`) enables correct 21-damage lethal checks for partner/multi-commander games — per MTG rules, 21 must come from a single commander, not combined
- **Per-seat aggregate preserved**: Existing `commander_damage_received` (keyed by seat) still maintained for GUI matrix and prompt builder backward compatibility
- **Trample + commander**: Trample overflow through blockers correctly counts as commander damage
- **Double strike + commander**: Both strikes count toward commander damage
- **Elimination check**: Combat now checks `is_dead_to_commander_damage()` alongside life <= 0
- **CommanderPlayer/Player sync**: `CommanderPlayer.commander_damage_received` is now a property delegating to `base.Player`, eliminating split-brain between the engine (which writes to Player) and the wrapper

### What remains deferred (from Issue #86)
- **Damage prevention/replacement effects**: No prevention or replacement layer exists yet; commander damage through effects like Fog or damage doublers is not modeled
- **Non-combat commander damage**: Abilities that deal damage (e.g., Niv-Mizzet ping) are not tracked as commander damage — only combat damage is covered
- **Instant-speed interaction during combat** (Issue #86 item 1): Not touched
- **Mulligan/opening hand** (Issue #86 item 3): Not touched
- **Full turn-structure fidelity** (Issue #86 item 4): Not touched

## Test plan
- [x] 22 new regression tests in `tests/test_commander_damage.py` covering:
  - Unblocked commander damage (single, mixed, cumulative)
  - 21-damage lethal (per-card, per-seat, backward compat)
  - Trample overflow as commander damage
  - Fully blocked commander (no player damage)
  - Double strike commander
  - Partner commanders tracked individually
  - Partner 21 check per-card (not combined)
  - CommanderGameState integration (with/without name)
  - Property delegation between CommanderPlayer and Player
  - Event log annotation
  - Lifelink + commander interaction
  - Player model initialization
- [x] Full test suite: 353 passed, 30 skipped (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)