### PR TITLE
ci: remove broken frontend workflow job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,26 +33,6 @@ jobs:
       - name: Run tests
         run: pytest -v --tb=short tests/ || true
 
-  frontend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Build frontend
-        working-directory: frontend
-        run: |
-          npm ci
-          npm run build
-
-      - name: Run frontend tests
-        working-directory: frontend
-        run: npx vitest run
-
   java-tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Removes the frontend CI job that was failing on every PR because it expected a non-existent frontend/ directory.\n\nSummary:\n- remove the Node-based frontend job from ci.yml\n- keep the Python and Java test jobs unchanged\n- align CI with the actual repo layout, which uses static UI assets under ui/\n\nThis should eliminate the recurring false-negative frontend failure on otherwise valid pull requests.