### PR TITLE
fix: correct indentation of last_err in DeepSeekBrain.choose_action()

### DIFF
--- a/src/commander_ai_lab/sim/deepseek_brain.py
+++ b/src/commander_ai_lab/sim/deepseek_brain.py
@@ -590,7 +590,7 @@ class DeepSeekBrain:
         if not self._connected:
             return self._fallback_action(snapshot, t_start, "not_connected")
 
-    last_err = None
+        last_err = None
         for attempt in range(1, self.config.max_retries + 1):
             try:
                 result = self._call_llm(snapshot)


### PR DESCRIPTION
## Summary
- Fixed `IndentationError` that prevented `deepseek_brain.py` from importing: `last_err = None` on line 593 was indented at 4 spaces (module level) instead of 8 spaces (method body level) inside `DeepSeekBrain.choose_action()`.

## Test plan
- [x] `ast.parse()` confirms valid Python syntax
- [x] `from commander_ai_lab.sim.deepseek_brain import DeepSeekBrain` succeeds after `pip install -e .`

---
🤖 *Generated by Computer*