### PR TITLE
fix: default Ollama endpoints to localhost instead of 192.168.0.240

### DIFF
--- a/coach/config.py
+++ b/coach/config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 LAB_ROOT = Path(os.environ.get("COMMANDER_LAB_ROOT", Path(__file__).parent.parent))
 
 # ── Ollama (OpenAI-compatible API) ──────────────────────
-LLM_URL = os.environ.get("LLM_URL", "http://192.168.0.240:11434/v1")
+LLM_URL = os.environ.get("LLM_URL", "http://localhost:11434/v1")
 LLM_MODEL = os.environ.get("LLM_MODEL", "gpt-oss:20b")
 LLM_TIMEOUT = int(os.environ.get("LLM_TIMEOUT", "360"))  # seconds
 LLM_MAX_RETRIES = 3
@@ -44,7 +44,7 @@ DEFAULT_MAX_TOKENS = 8192
 DECK_GEN_PROVIDER = os.environ.get("DECK_GEN_PROVIDER", "local")
 # Model for deck generation (sonar = fast/$0.004, sonar-pro = deep/$0.04)
 DECK_GEN_MODEL = os.environ.get("DECK_GEN_MODEL", "gpt-oss:20b")
-DECK_GEN_BASE_URL = os.environ.get("DECK_GEN_BASE_URL", "http://192.168.0.240:11434/v1")
+DECK_GEN_BASE_URL = os.environ.get("DECK_GEN_BASE_URL", "http://localhost:11434/v1")
 DECK_GEN_TEMPERATURE = float(os.environ.get("DECK_GEN_TEMPERATURE", "0.2"))
 DECK_GEN_MAX_TOKENS = int(os.environ.get("DECK_GEN_MAX_TOKENS", "16384"))
 

--- a/lab_api.py
+++ b/lab_api.py
@@ -45,7 +45,7 @@ from routes.ml import router as ml_router
 log = logging.getLogger("commander_ai_lab.api")
 
 # ── CORS origins (env-configurable) ────────────────────────────
-_DEFAULT_ORIGINS = "http://localhost:5173,http://localhost:8080,http://192.168.0.240:5173,http://192.168.0.240:8080"
+_DEFAULT_ORIGINS = "http://localhost:5173,http://localhost:8080"
 _allowed = os.environ.get("ALLOWED_ORIGINS", _DEFAULT_ORIGINS)
 allowed_origins = [o.strip() for o in _allowed.split(",") if o.strip()]
 

--- a/routes/coach.py
+++ b/routes/coach.py
@@ -87,7 +87,7 @@ def init_coach_service():
         if llm_status.get("connected"):
             log_coach.info(f"  Coach LLM:    Connected ({llm_status.get('active_model', 'unknown')})")
         else:
-            log_coach.warning(f"  Coach LLM:    Not connected (start Ollama on 192.168.0.240:11434)")
+            log_coach.warning(f"  Coach LLM:    Not connected (start Ollama on localhost:11434)")
 
         # Initialize V3 Deck Generator (Ollama-based)
         _deck_gen_v3_error = None

--- a/src/commander_ai_lab/sim/deepseek_brain.py
+++ b/src/commander_ai_lab/sim/deepseek_brain.py
@@ -9,7 +9,7 @@ The LLM receives a structured game-state snapshot and returns a JSON
 action describing what to do this turn (play land, cast spell, attack,
 hold/pass, use removal, use board wipe, cast ramp, cast commander).
 
-Default target: GPT-OSS 20B (Q4_K_M) via Ollama at 192.168.0.240:11434
+Default target: GPT-OSS 20B (Q4_K_M) via Ollama at localhost:11434
   ollama run deepseek-r1:8b
 
 Also supports:
@@ -64,7 +64,7 @@ class DeepSeekConfig:
         )
 
     Example — Ollama (default)::
-        config = DeepSeekConfig()  # points at 192.168.0.240:11434 / deepseek-r1:8b
+        config = DeepSeekConfig()  # points at localhost:11434 / deepseek-r1:8b
     """
 
     # API endpoint — Ollama OpenAI-compatible base (NO /v1 suffix)

--- a/src/commander_ai_lab/sim/deepseek_engine.py
+++ b/src/commander_ai_lab/sim/deepseek_engine.py
@@ -23,7 +23,7 @@ Usage::
     from commander_ai_lab.sim.deepseek_engine import DeepSeekGameEngine
     from commander_ai_lab.sim.deepseek_brain import DeepSeekBrain, DeepSeekConfig
 
-    brain = DeepSeekBrain(DeepSeekConfig(api_base="http://192.168.0.240:11434"))
+    brain = DeepSeekBrain(DeepSeekConfig(api_base="http://localhost:11434"))
     brain.check_connection()
     engine = DeepSeekGameEngine(brain=brain, ai_player_index=1)
     result = engine.run(deck_a, deck_b, name_a="My Deck", name_b="DeepSeek AI")

--- a/src/commander_ai_lab/sim/validator_brain.py
+++ b/src/commander_ai_lab/sim/validator_brain.py
@@ -50,7 +50,7 @@ class ValidatorConfig:
 
     Example -- LM Studio::
         cfg = ValidatorConfig(
-            api_base="http://192.168.0.240:1234",
+            api_base="http://localhost:1234",
             model="deepseek-r1-distill-qwen-14b",
         )
     """

--- a/ui/simulator.html
+++ b/ui/simulator.html
@@ -62,7 +62,7 @@
                 <div class="deepseek-config-row">
                     <div class="form-group sim-field-grow">
                         <label class="form-label" for="ds-api-base">API Endpoint</label>
-                        <input type="text" id="ds-api-base" class="form-input" value="http://192.168.0.240:11434" placeholder="http://192.168.0.240:11434" />
+                        <input type="text" id="ds-api-base" class="form-input" value="http://localhost:11434" placeholder="http://localhost:11434" />
                     </div>
                     <div class="form-group sim-field-auto">
                         <label class="form-label" for="ds-model">Model</label>


### PR DESCRIPTION
## Summary

- Replace all hardcoded `192.168.0.240` Ollama endpoint defaults with `localhost` across the project
- This was a developer-specific LAN IP that prevented the project from working out-of-the-box for anyone running Ollama locally or via WSL2 on Windows
- All defaults remain env-overridable (`LLM_URL`, `DECK_GEN_BASE_URL`, `ALLOWED_ORIGINS`) so users with remote Ollama setups can still configure their IP

## Changes

| File | What changed |
|------|-------------|
| `coach/config.py` | `LLM_URL` and `DECK_GEN_BASE_URL` defaults → `localhost` |
| `ui/simulator.html` | API endpoint input `value` and `placeholder` → `localhost` |
| `lab_api.py` | Removed `192.168.0.240` entries from default CORS origins |
| `routes/coach.py` | Warning message now says `localhost:11434` |
| `src/commander_ai_lab/sim/deepseek_brain.py` | Docstrings updated |
| `src/commander_ai_lab/sim/deepseek_engine.py` | Docstring example updated |
| `src/commander_ai_lab/sim/validator_brain.py` | Docstring example updated |

## Test plan

- [x] Verified zero `192.168.0.240` references remain in the codebase (`grep` returns no matches)
- [x] All changed Python files compile successfully (`py_compile`)
- [x] `coach/config.py` imports cleanly
- [x] `DeepSeekConfig().api_base` resolves to `http://localhost:11434` at runtime
- [x] Confirmed pre-existing test failures on `main` are unrelated to these changes

---
🤖 *Generated by Computer*